### PR TITLE
subcorpora & concordances

### DIFF
--- a/cads/collocation.py
+++ b/cads/collocation.py
@@ -316,7 +316,7 @@ def ccc_collocates(collocation, window=None, cut_off=500, min_freq=3):
 
 class CollocationIn(Schema):
 
-    query_id = Integer(required=True)
+    # query_id = Integer(required=True)
     constellation_id = Integer()
     p = String(required=True)
     s_break = String(required=True)

--- a/cads/concordance.py
+++ b/cads/concordance.py
@@ -210,7 +210,6 @@ def lines(query_id, data):
         structural = dict()
         for s_att in s_show + [s + "_cwbid" for s in s_show]:
             structural[s_att] = line[s_att]
-        print(structural)
 
         rows.append({
             'match': line['match'],

--- a/cads/concordance.py
+++ b/cads/concordance.py
@@ -196,7 +196,7 @@ def lines(query_id, data):
     rows = list()
     for line in concordance_lines:
         tokens = list()
-        for cpos, offset, prim, sec, roles in zip(line['cpos'], line['offset'], line[p_show[0]], line[p_show[0]], line['role']):
+        for cpos, offset, prim, sec, roles in zip(line['cpos'], line['offset'], line[p_show[0]], line[p_show[1]], line['role']):
             tokens.append({
                 'cpos': cpos,
                 'offset': offset,

--- a/cads/concordance.py
+++ b/cads/concordance.py
@@ -108,11 +108,22 @@ def highlight(lines, discoursemes, p_att='lemma', bools=True):
 class ConcordanceIn(Schema):
 
     context_break = String(dump_default='text', required=False)
-    p_show = List(String, default=['word', 'lemma'], required=False)
+    window = Integer(default=20, required=False)
+
     s_show = List(String, default=[], required=False)
+
+    p_show = List(String, default=['word', 'lemma'], required=False)
+    # primary
+    # secondary
+
     order = Integer(default=42, required=False)
     cut_off = Integer(default=500, required=False)
-    window = Integer(default=20, required=False)
+    # page_size
+    # page_index
+    # sort_by (offset)
+    # sort_order (ascending, descending)
+
+    # absolute context break
 
 
 class ConcordanceLinesOutMMDA(Schema):
@@ -135,6 +146,7 @@ class TokenOut(Schema):
     lemma = String()
     out_of_window = Boolean()
     discourseme_ids = List(Integer)
+    # is_highlight / search (also for concordance in!)
 
 
 class ConcordanceLineOut(Schema):
@@ -150,7 +162,8 @@ class ConcordanceLineOut(Schema):
 # - page size / page number
 
 # Concordance context extension
-# - concordance lines have to be identifable!
+# - concordance lines have to be identifiable!
+# - save display settings
 
 
 @bp.get("/")

--- a/cads/corpus.py
+++ b/cads/corpus.py
@@ -261,6 +261,10 @@ def get_meta(id):
     # corpus = {**corpus, **attributes}
 
     # return corpus, 200
+    # datetime/numeric: min, maximum
+    # boolean: yes/no
+    # unicode: searchable endpoint: einzelne Auswahl
+    # array of filter_object:
 
 
 @bp.put('/<id>/meta')

--- a/cads/discourseme.py
+++ b/cads/discourseme.py
@@ -46,6 +46,7 @@ class DiscoursemeIn(Schema):
 
     name = String()
     description = String()
+    # _items = List(String())     # TODO
 
 
 class DiscoursemeOut(Schema):
@@ -53,7 +54,10 @@ class DiscoursemeOut(Schema):
     id = Integer()
     name = String()
     description = String()
-    _items = List(String())
+    _items = List(String())     # TODO
+
+
+# Endpunkt, um Items aus Diskurem entfernen
 
 
 @bp.post('/')

--- a/cads/discourseme.py
+++ b/cads/discourseme.py
@@ -48,6 +48,8 @@ class DiscoursemeIn(Schema):
     description = String()
     # _items = List(String())     # TODO
 
+    # color TODO
+
 
 class DiscoursemeOut(Schema):
 

--- a/cads/discourseme.py
+++ b/cads/discourseme.py
@@ -120,12 +120,12 @@ def get_discoursemes():
 class DiscoursemeQueryIn(Schema):
 
     corpus_id = Integer()
-    match_strategy = String(load_default='longest')
-    p_query = String(load_default='lemma')
-    s_query = String(load_default=None)
-    flags = String(load_default="")
+    subcorpus_id = String(required=False, load_default=None)
+    match_strategy = String(required=False, load_default='longest')
+    p_query = String(required=False, load_default='word')
+    s_query = String(required=True)
+    flags = String(required=False, load_default="")
     escape = Boolean(load_default=False)
-    nqr_name = String(load_default=None)
 
 
 @bp.post('/<id>/query')
@@ -143,7 +143,7 @@ def query(id, data, data_query):
         corpus_id=data['corpus_id'],
         match_strategy=data['match_strategy'],
         cqp_query=format_cqp_query(discourseme.get_items(), data['p_query'], data['s_query'], data['flags'], data['escape']),
-        nqr_name=data['nqr_name']
+        subcorpus_id=data['subcorpus_id']
     )
     db.session.add(query)
     db.session.commit()

--- a/cads/mmda/collocation_views.py
+++ b/cads/mmda/collocation_views.py
@@ -437,10 +437,10 @@ def get_collocate_for_collocation(username, collocation):
         # SubCorpus
         subcorpus_name = "SOC" + "-" + "-".join([str(collocation._query.discourseme.id)] + [str(discourseme.id) for discourseme in filter_discoursemes])
         subcorpus = SubCorpus.query.filter_by(
-            corpus_id=collocation._query.corpus.id, name=subcorpus_name, description='SOC', cqp_nqr_matches=nqr_name
+            corpus_id=collocation._query.corpus.id, name=subcorpus_name, description='SOC', nqr_cqp=nqr_name
         ).first()
         if not subcorpus:
-            subcorpus = SubCorpus(corpus_id=collocation._query.corpus.id, name=subcorpus_name, description='SOC', cqp_nqr_matches=nqr_name)
+            subcorpus = SubCorpus(corpus_id=collocation._query.corpus.id, name=subcorpus_name, description='SOC', nqr_cqp=nqr_name)
             db.session.add(subcorpus)
 
         # Query
@@ -551,9 +551,9 @@ def get_concordance_for_collocation(username, collocation):
     # .. parameters
     window = int(request.args.get('window_size', 10))
     corpus = ccc_corpus_attributes(collocation._query.corpus.cwb_id,
-                        cqp_bin=current_app.config['CCC_CQP_BIN'],
-                        registry_dir=current_app.config['CCC_REGISTRY_DIR'],
-                        data_dir=current_app.config['CCC_DATA_DIR'])
+                                   cqp_bin=current_app.config['CCC_CQP_BIN'],
+                                   registry_dir=current_app.config['CCC_REGISTRY_DIR'],
+                                   data_dir=current_app.config['CCC_DATA_DIR'])
     s_show = corpus['s_annotations']
     p_show = ['word', collocation.p]
     cut_off = request.args.get('cut_off', 500)
@@ -569,7 +569,7 @@ def get_concordance_for_collocation(username, collocation):
                                               name=subcorpus_name).first()
         query = Query.query.filter_by(corpus_id=corpus_id,
                                       discourseme=collocation._query.discourseme,
-                                      nqr_name=subcorpus.cqp_nqr_matches,
+                                      nqr_name=subcorpus.nqr_cqp,
                                       cqp_query=collocation._query.cqp_query).first()
         collocation = Collocation.query.filter_by(query_id=query.id,
                                                   s_break=collocation.s_break,

--- a/cads/users.py
+++ b/cads/users.py
@@ -59,7 +59,7 @@ class HTTPRefreshTokenIn(Schema):
 def verify_token(token):
 
     if not token:
-        return abort(403, "invalid token")
+        return abort(403, "missing authorization header")
     data = decode_token(token)
     user = db.get_or_404(User, data['sub']['id'])
 

--- a/cads/users.py
+++ b/cads/users.py
@@ -44,9 +44,14 @@ class UserOut(Schema):
     # roles = List(String())
 
 
-class TokenOut(Schema):
+class HTTPTokenOut(Schema):
 
-    access_token = String()
+    access_token = String(required=False)
+    refresh_token = String(required=False)
+
+
+class HTTPRefreshTokenIn(Schema):
+
     refresh_token = String()
 
 
@@ -63,7 +68,7 @@ def verify_token(token):
 
 @bp.post('/login')
 @bp.input(UserIn, location='form')
-@bp.output(TokenOut)
+@bp.output(HTTPTokenOut)
 def login(data):
     """Login with name and password to get JWT token
 
@@ -87,12 +92,16 @@ def login(data):
 
 
 @bp.post('/refresh')
-@bp.output(TokenOut)
-def refresh():
+@bp.input(HTTPRefreshTokenIn)
+@bp.output(HTTPTokenOut)
+def refresh(data):
     """Return a new token if the user has a refresh token
 
     """
-    # TODO: parse refresh token
+
+    refresh_token = data['refresh_token']
+    data = decode_token(refresh_token)
+    user = db.get_or_404(User, data['sub']['id'])
 
     tokens = {
         'access_token': create_access_token(UserOut().dump(user)),

--- a/cads/users.py
+++ b/cads/users.py
@@ -88,13 +88,11 @@ def login(data):
 
 @bp.post('/refresh')
 @bp.output(TokenOut)
-@bp.auth_required(auth)
 def refresh():
     """Return a new token if the user has a refresh token
 
     """
-
-    user = auth.current_user
+    # TODO: parse refresh token
 
     tokens = {
         'access_token': create_access_token(UserOut().dump(user)),

--- a/cfg.py
+++ b/cfg.py
@@ -40,7 +40,7 @@ class ProdConfig(Config):
 
     CCC_DATA_DIR = str(getenv('CCC_DATA_DIR', default='/tmp/mmda-ccc-data/'))
 
-    JWT_ACCESS_TOKEN_EXPIRES = 60*60*12
+    JWT_ACCESS_TOKEN_EXPIRES = 60*30
     JWT_REFRESH_TOKEN_EXPIRES = 60*60*12
 
 

--- a/openapi.json
+++ b/openapi.json
@@ -472,7 +472,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TokenOut"
+                  "$ref": "#/components/schemas/HTTPTokenOut"
                 }
               }
             },
@@ -764,32 +764,36 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TokenOut"
+                  "$ref": "#/components/schemas/HTTPTokenOut"
                 }
               }
             },
             "description": "Successful response"
           },
-          "401": {
+          "422": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPError"
+                  "$ref": "#/components/schemas/ValidationError"
                 }
               }
             },
-            "description": "Authentication error"
+            "description": "Validation error"
           }
         },
         "tags": [
           "User"
         ],
         "summary": "Return a new token if the user has a refresh token",
-        "security": [
-          {
-            "BearerAuth": []
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPRefreshTokenIn"
+              }
+            }
           }
-        ]
+        }
       }
     },
     "/discourseme/": {
@@ -2906,7 +2910,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ConcordanceLinesOut"
+                    "$ref": "#/components/schemas/ConcordanceLineOut"
                   }
                 }
               }
@@ -5414,18 +5418,17 @@
           "corpus": {
             "$ref": "#/components/schemas/CorpusOut"
           },
+          "subcorpus_id": {
+            "type": "integer"
+          },
           "match_strategy": {
             "type": "string"
           },
           "cqp_query": {
             "type": "string"
           },
-          "cqp_nqr_matches": {
+          "nqr_cqp": {
             "type": "string"
-          },
-          "nqr_name": {
-            "type": "string",
-            "nullable": true
           },
           "subcorpus": {
             "type": "string",
@@ -5443,6 +5446,9 @@
           "corpus_id": {
             "type": "integer"
           },
+          "subcorpus_id": {
+            "type": "integer"
+          },
           "match_strategy": {
             "type": "string",
             "enum": [
@@ -5453,10 +5459,6 @@
           },
           "cqp_query": {
             "type": "string"
-          },
-          "nqr_name": {
-            "type": "string",
-            "nullable": true
           },
           "s": {
             "type": "string"
@@ -5502,7 +5504,7 @@
           "username"
         ]
       },
-      "TokenOut": {
+      "HTTPTokenOut": {
         "type": "object",
         "properties": {
           "access_token": {
@@ -5523,6 +5525,9 @@
           "corpus_id": {
             "type": "integer"
           },
+          "subcorpus_id": {
+            "type": "integer"
+          },
           "match_strategy": {
             "type": "string",
             "enum": [
@@ -5534,11 +5539,15 @@
           "cqp_query": {
             "type": "string"
           },
-          "nqr_name": {
-            "type": "string",
-            "nullable": true
-          },
           "s": {
+            "type": "string"
+          }
+        }
+      },
+      "HTTPRefreshTokenIn": {
+        "type": "object",
+        "properties": {
+          "refresh_token": {
             "type": "string"
           }
         }
@@ -5693,6 +5702,9 @@
           "corpus_id": {
             "type": "integer"
           },
+          "subcorpus_id": {
+            "type": "integer"
+          },
           "match_strategy": {
             "type": "string",
             "enum": [
@@ -5700,10 +5712,6 @@
               "shortest",
               "standard"
             ]
-          },
-          "nqr_name": {
-            "type": "string",
-            "nullable": true
           },
           "items": {
             "type": "array",
@@ -5714,9 +5722,6 @@
           "p": {
             "type": "string"
           },
-          "s": {
-            "type": "string"
-          },
           "ignore_case": {
             "type": "boolean"
           },
@@ -5725,6 +5730,9 @@
           },
           "escape": {
             "type": "boolean"
+          },
+          "s": {
+            "type": "string"
           }
         },
         "required": [
@@ -5757,18 +5765,21 @@
           "corpus_id": {
             "type": "integer"
           },
+          "subcorpus_id": {
+            "type": "string",
+            "default": null,
+            "nullable": true
+          },
           "match_strategy": {
             "type": "string",
             "default": "longest"
           },
           "p_query": {
             "type": "string",
-            "default": "lemma"
+            "default": "word"
           },
           "s_query": {
-            "type": "string",
-            "default": null,
-            "nullable": true
+            "type": "string"
           },
           "flags": {
             "type": "string",
@@ -5777,13 +5788,11 @@
           "escape": {
             "type": "boolean",
             "default": false
-          },
-          "nqr_name": {
-            "type": "string",
-            "default": null,
-            "nullable": true
           }
-        }
+        },
+        "required": [
+          "s_query"
+        ]
       },
       "SubCorpusOut": {
         "type": "object",
@@ -5800,7 +5809,7 @@
           "description": {
             "type": "string"
           },
-          "cqp_nqr_matches": {
+          "nqr_cqp": {
             "type": "string"
           }
         }
@@ -5819,9 +5828,6 @@
       "CollocationIn": {
         "type": "object",
         "properties": {
-          "query_id": {
-            "type": "integer"
-          },
           "constellation_id": {
             "type": "integer"
           },
@@ -5838,21 +5844,49 @@
         "required": [
           "context",
           "p",
-          "query_id",
           "s_break"
         ]
       },
-      "ConcordanceLinesOut": {
+      "TokenOut": {
+        "type": "object",
+        "properties": {
+          "cpos": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          },
+          "word": {
+            "type": "string"
+          },
+          "lemma": {
+            "type": "string"
+          },
+          "out_of_window": {
+            "type": "boolean"
+          },
+          "discourseme_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "ConcordanceLineOut": {
         "type": "object",
         "properties": {
           "match": {
             "type": "integer"
           },
-          "positional": {
-            "type": "string"
+          "tokens": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TokenOut"
+            }
           },
           "structural": {
-            "type": "string"
+            "type": "object"
           }
         }
       },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,9 @@
 import pytest
 
 from cads import create_app
-from cads.database import init_db
 from cads import db
+from cads.database import init_db
+from cads.corpus import init_corpora
 from cads.database import Discourseme
 from cads.discourseme import read_tsv
 
@@ -13,7 +14,10 @@ app = create_app('cfg.TestConfig')
 
 # create new database
 with app.app_context():
+
     init_db()
+
+    init_corpora()
 
     # TODO exclude the ones that are already in database?
     discoursemes = read_tsv("tests/discoursemes/germaparl.tsv")
@@ -28,11 +32,12 @@ class AuthActions(object):
         self._client = client
 
     def login(self, username="admin", password="0000"):
-        return self._client.post(
+        token = self._client.post(
             "/user/login",
             data={"username": username, "password": password},
             content_type='application/x-www-form-urlencoded'
-        )
+        ).json['access_token']
+        return {"Authorization": f"Bearer {token}"}
 
     def logout(self):
         return self._client.get("/auth/logout")

--- a/tests/test_breakdown.py
+++ b/tests/test_breakdown.py
@@ -3,7 +3,7 @@ from flask import url_for
 
 def test_create_get_breakdown(client, auth):
 
-    auth.login()
+    auth_header = auth.login()
     with client:
         client.get("/")
 
@@ -13,7 +13,7 @@ def test_create_get_breakdown(client, auth):
                                       'name': 'CDU',
                                       'description': 'Test Query'
                                   },
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
 
         # query
         query = client.post(url_for('query.create'),
@@ -22,28 +22,28 @@ def test_create_get_breakdown(client, auth):
                                 'corpus_id': 1,
                                 'cqp_query': '[word="die"]? [lemma="CDU"]'
                             },
-                            auth=('admin', '0000'))
+                            headers=auth_header)
 
         # create matches
         query = client.post(url_for('query.execute', id=query.json['id']),
-                            auth=('admin', '0000'))
+                            headers=auth_header)
 
         # breakdown
         breakdown = client.post(url_for('breakdown.create', query_id=query.json['id']),
                                 json={
                                     'p': 'lemma'
                                 },
-                                auth=('admin', '0000'))
+                                headers=auth_header)
 
         assert breakdown.status_code == 200
 
         breakdowns = client.get(url_for('breakdown.get_breakdowns', query_id=1),
-                                auth=('admin', '0000'))
+                                headers=auth_header)
 
         response = client.get(url_for('breakdown.get_breakdown', query_id=breakdowns.json[0]['query_id'], id=breakdowns.json[0]['id']),
-                              auth=('admin', '0000'))
+                              headers=auth_header)
 
         response = client.post(url_for('breakdown.execute', query_id=1, id=1),
                                json={'p': 'lemma'},
-                               auth=('admin', '0000'))
+                               headers=auth_header)
         assert response.status_code == 200

--- a/tests/test_breakdown.py
+++ b/tests/test_breakdown.py
@@ -7,25 +7,13 @@ def test_create_get_breakdown(client, auth):
     with client:
         client.get("/")
 
-        # discourseme
-        discourseme = client.post(url_for('discourseme.create'),
-                                  json={
-                                      'name': 'CDU',
-                                      'description': 'Test Query'
-                                  },
-                                  headers=auth_header)
-
         # query
         query = client.post(url_for('query.create'),
                             json={
-                                'discourseme_id': discourseme.json['id'],
                                 'corpus_id': 1,
-                                'cqp_query': '[word="die"]? [lemma="CDU"]'
+                                'cqp_query': '[word="die"]? [lemma="CDU"]',
+                                's': 's'
                             },
-                            headers=auth_header)
-
-        # create matches
-        query = client.post(url_for('query.execute', id=query.json['id']),
                             headers=auth_header)
 
         # breakdown

--- a/tests/test_collocation.py
+++ b/tests/test_collocation.py
@@ -1,5 +1,6 @@
 from flask import url_for
 from cads.database import Collocation
+import pytest
 
 
 def test_create_collocation(client, auth):
@@ -16,6 +17,7 @@ def test_create_collocation(client, auth):
                                       'description': 'Test Discourseme 1'
                                   },
                                   headers=auth_header)
+
         # constellation
         constellation = client.post(url_for('constellation.create'),
                                     json={
@@ -24,6 +26,8 @@ def test_create_collocation(client, auth):
                                         'filter_discourseme_ids': [discourseme.json['id']]
                                     },
                                     headers=auth_header)
+
+        assert constellation.status_code == 200
 
         constellation = client.get(url_for('constellation.get_constellation', id=constellation.json['id']),
                                    headers=auth_header)
@@ -34,12 +38,9 @@ def test_create_collocation(client, auth):
                             json={
                                 'discourseme_id': discourseme.json['id'],
                                 'corpus_id': 1,
-                                'cqp_query': '[lemma="und"]'
+                                'cqp_query': '[lemma="und"]',
+                                's': 's'
                             },
-                            headers=auth_header)
-
-        # - execute
-        query = client.post(url_for('query.execute', id=query.json['id']),
                             headers=auth_header)
 
         # collocation
@@ -88,7 +89,8 @@ def test_create_or_get_cooc(client, auth):
                             json={
                                 'discourseme_id': discourseme.json['id'],
                                 'corpus_id': 1,
-                                'cqp_query': '[lemma="und"]'
+                                'cqp_query': '[lemma="und"]',
+                                's': 's'
                             },
                             headers=auth_header)
 

--- a/tests/test_collocation.py
+++ b/tests/test_collocation.py
@@ -4,7 +4,7 @@ from cads.database import Collocation
 
 def test_create_collocation(client, auth):
 
-    auth.login()
+    auth_header = auth.login()
     with client:
         client.get("/")
 
@@ -15,7 +15,7 @@ def test_create_collocation(client, auth):
                                       'name': 'CDU',
                                       'description': 'Test Discourseme 1'
                                   },
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
         # constellation
         constellation = client.post(url_for('constellation.create'),
                                     json={
@@ -23,10 +23,10 @@ def test_create_collocation(client, auth):
                                         'description': 'Test Constellation 1',
                                         'filter_discourseme_ids': [discourseme.json['id']]
                                     },
-                                    auth=('admin', '0000'))
+                                    headers=auth_header)
 
         constellation = client.get(url_for('constellation.get_constellation', id=constellation.json['id']),
-                                   auth=('admin', '0000'))
+                                   headers=auth_header)
 
         # query
         # - create
@@ -36,11 +36,11 @@ def test_create_collocation(client, auth):
                                 'corpus_id': 1,
                                 'cqp_query': '[lemma="und"]'
                             },
-                            auth=('admin', '0000'))
+                            headers=auth_header)
 
         # - execute
         query = client.post(url_for('query.execute', id=query.json['id']),
-                            auth=('admin', '0000'))
+                            headers=auth_header)
 
         # collocation
         # - create
@@ -51,14 +51,14 @@ def test_create_collocation(client, auth):
                                       's_break': 's',
                                       'context': 10,
                                   },
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
 
         assert collocation.status_code == 200
 
 
 def test_create_or_get_cooc(client, auth):
 
-    auth.login()
+    auth_header = auth.login()
     with client:
         client.get("/")
 
@@ -69,7 +69,7 @@ def test_create_or_get_cooc(client, auth):
                                       'name': 'CDU',
                                       'description': 'Test Discourseme 2'
                                   },
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
         # constellation
         constellation = client.post(url_for('constellation.create'),
                                     json={
@@ -77,10 +77,10 @@ def test_create_or_get_cooc(client, auth):
                                         'description': 'Test Constellation 2',
                                         'filter_discourseme_ids': [discourseme.json['id']]
                                     },
-                                    auth=('admin', '0000'))
+                                    headers=auth_header)
 
         constellation = client.get(url_for('constellation.get_constellation', id=constellation.json['id']),
-                                   auth=('admin', '0000'))
+                                   headers=auth_header)
 
         # query
         # - create
@@ -90,11 +90,11 @@ def test_create_or_get_cooc(client, auth):
                                 'corpus_id': 1,
                                 'cqp_query': '[lemma="und"]'
                             },
-                            auth=('admin', '0000'))
+                            headers=auth_header)
 
         # - execute
         query = client.post(url_for('query.execute', id=query.json['id']),
-                            auth=('admin', '0000'))
+                            headers=auth_header)
 
         # collocation
         # - create
@@ -105,7 +105,7 @@ def test_create_or_get_cooc(client, auth):
                                       's_break': 's',
                                       'context': 10,
                                   },
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
 
         collocation = Collocation.query.filter_by(id=collocation.json['id']).first()
 
@@ -118,17 +118,17 @@ def test_create_or_get_cooc(client, auth):
 
 def test_execute_collocation(client, auth):
 
-    auth.login()
+    auth_header = auth.login()
     with client:
         client.get("/")
 
         collocation = client.post(url_for('collocation.execute', query_id=1, id=1),
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
 
         collocation = client.post(url_for('collocation.execute', query_id=1, id=1),
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
 
         items = client.get(url_for('collocation.get_collocation_items', query_id=1, id=collocation.json['id']),
-                           auth=('admin', '0000'))
+                           headers=auth_header)
 
         assert items.status_code == 200

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -1,4 +1,5 @@
 from flask import url_for
+# from pprint import pprint
 
 
 def test_create_get_concordance(client, auth):
@@ -25,8 +26,13 @@ def test_create_get_concordance(client, auth):
                             },
                             headers=auth_header)
 
-        # concordance
-        lines = client.get(url_for('query.concordance.lines', query_id=query.json['id'], s_show=['text_parliamentary_group']),
+        lines = client.get(url_for('query.concordance.lines', query_id=query.json['id'], s_show=['text_parliamentary_group'], page_size=10, page_number=6),
                            headers=auth_header)
-
         assert lines.status_code == 200
+
+        # pprint(lines.json[0])
+        # print(len(lines.json))
+
+        line = client.get(url_for('query.concordance.context', id=65059, query_id=query.json['id'], s_show=['text_parliamentary_group'], window=50),
+                          headers=auth_header)
+        assert line.status_code == 200

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -3,7 +3,7 @@ from flask import url_for
 
 def test_create_get_concordance(client, auth):
 
-    auth.login()
+    auth_header = auth.login()
     with client:
         client.get("/")
 
@@ -13,7 +13,7 @@ def test_create_get_concordance(client, auth):
                                       'name': 'CDU',
                                       'description': 'Test Query'
                                   },
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
 
         # query
         query = client.post(url_for('query.create'),
@@ -22,10 +22,10 @@ def test_create_get_concordance(client, auth):
                                 'corpus_id': 1,
                                 'cqp_query': '[lemma="Bundeskanzler"]'
                             },
-                            auth=('admin', '0000'))
+                            headers=auth_header)
 
         # concordance
         lines = client.get(url_for('query.concordance.lines', query_id=query.json['id']),
-                           auth=('admin', '0000'))
+                           headers=auth_header)
 
         assert lines.status_code == 200

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -20,12 +20,13 @@ def test_create_get_concordance(client, auth):
                             json={
                                 'discourseme_id': discourseme.json['id'],
                                 'corpus_id': 1,
-                                'cqp_query': '[lemma="Bundeskanzler"]'
+                                'cqp_query': '[lemma="Bundeskanzler"]',
+                                's': 's'
                             },
                             headers=auth_header)
 
         # concordance
-        lines = client.get(url_for('query.concordance.lines', query_id=query.json['id']),
+        lines = client.get(url_for('query.concordance.lines', query_id=query.json['id'], s_show=['text_parliamentary_group']),
                            headers=auth_header)
 
         assert lines.status_code == 200

--- a/tests/test_constellations.py
+++ b/tests/test_constellations.py
@@ -3,7 +3,7 @@ from flask import url_for
 
 def test_create_get_constellation(client, auth):
 
-    auth.login()
+    auth_header = auth.login()
     with client:
         client.get("/")
 
@@ -13,7 +13,7 @@ def test_create_get_constellation(client, auth):
                                       'name': 'CDU',
                                       'description': 'Test Discourseme'
                                   },
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
 
         # constellation
         constellation = client.post(url_for('constellation.create'),
@@ -22,12 +22,12 @@ def test_create_get_constellation(client, auth):
                                         'description': 'Test Constellation',
                                         'filter_discourseme_ids': [discourseme.json['id']]
                                     },
-                                    auth=('admin', '0000'))
+                                    headers=auth_header)
 
         constellation = client.get(url_for('constellation.get_constellation', id=constellation.json['id']),
-                                   auth=('admin', '0000'))
+                                   headers=auth_header)
 
         constellations = client.get(url_for('constellation.get_constellations'),
-                                    auth=('admin', '0000'))
+                                    headers=auth_header)
 
         assert constellations.status_code == 200

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -3,15 +3,19 @@ from flask import url_for
 
 def test_get_corpus(client, auth):
 
-    auth.login()
+    auth_header = auth.login()
+
     with client:
+
         client.get("/")
 
         # discourseme
         corpora = client.get(url_for('corpus.get_corpora'),
-                             auth=('admin', '0000'))
+                             content_type='application/json',
+                             headers=auth_header)
 
         corpus = client.get(url_for('corpus.get_corpus', id=corpora.json[0]['id']),
-                            auth=('admin', '0000'))
+                            content_type='application/json',
+                            headers=auth_header)
 
         assert corpus.status_code == 200

--- a/tests/test_discourseme.py
+++ b/tests/test_discourseme.py
@@ -3,7 +3,8 @@ from flask import url_for
 
 def test_create_get_discourseme(client, auth):
 
-    auth.login()
+    auth_header = auth.login()
+
     with client:
         client.get("/")
         discourseme = client.post(url_for('discourseme.create'),
@@ -11,14 +12,15 @@ def test_create_get_discourseme(client, auth):
                                       'name': 'test discourseme',
                                       'description': 'this is a test discourseme'
                                   },
-                                  auth=('admin', '0000'))
+                                  content_type='application/json',
+                                  headers=auth_header)
 
         assert discourseme.status_code == 200
 
         discourseme = client.get(url_for('discourseme.get_discourseme', id=discourseme.json['id']),
-                                 auth=('admin', '0000'))
+                                 headers=auth_header)
 
         discoursemes = client.get(url_for('discourseme.get_discoursemes'),
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
 
         assert discoursemes.status_code == 200

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -3,17 +3,17 @@ from flask import url_for
 
 def test_create_query(client, auth):
 
-    auth.login()
+    auth_header = auth.login()
     with client:
         client.get("/")
-
         # discourseme
         discourseme = client.post(url_for('discourseme.create'),
                                   json={
                                       'name': 'CDU',
                                       'description': 'Test Query'
                                   },
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
+
         assert discourseme.status_code == 200
 
         # query
@@ -23,24 +23,24 @@ def test_create_query(client, auth):
                                 'corpus_id': 1,
                                 'cqp_query': '[word="der"] [lemma="Bundeskanzler"]'
                             },
-                            auth=('admin', '0000'))
-
+                            headers=auth_header)
+        print(query.json)
         assert query.status_code == 200
 
         queries = client.get(url_for('query.get_queries'),
-                             auth=('admin', '0000'))
+                             headers=auth_header)
 
         query = client.get(url_for('query.get_query', id=queries.json[0]['id']),
-                           auth=('admin', '0000'))
+                           headers=auth_header)
 
         assert query.status_code == 200
 
 
 def test_execute_query(client, auth):
 
-    auth.login()
+    auth_header = auth.login()
     with client:
         client.get("/")
         response = client.post(url_for('query.execute', id=1),
-                               auth=('admin', '0000'))
+                               headers=auth_header)
         assert response.status_code == 200

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -21,10 +21,11 @@ def test_create_query(client, auth):
                             json={
                                 'discourseme_id': discourseme.json['id'],
                                 'corpus_id': 1,
-                                'cqp_query': '[word="der"] [lemma="Bundeskanzler"]'
+                                'cqp_query': '[word="der"] [lemma="Bundeskanzler"]',
+                                's': 's'
                             },
                             headers=auth_header)
-        print(query.json)
+
         assert query.status_code == 200
 
         queries = client.get(url_for('query.get_queries'),

--- a/tests/test_semantic_map.py
+++ b/tests/test_semantic_map.py
@@ -29,7 +29,8 @@ def test_create_semmap(client, auth):
                             json={
                                 'discourseme_id': discourseme.json['id'],
                                 'corpus_id': 1,
-                                'cqp_query': '[lemma="Bundeskanzler"]'
+                                'cqp_query': '[lemma="Bundeskanzler"]',
+                                's': 's'
                             },
                             headers=auth_header)
 

--- a/tests/test_semantic_map.py
+++ b/tests/test_semantic_map.py
@@ -3,7 +3,7 @@ from flask import url_for
 
 def test_create_semmap(client, auth):
 
-    auth.login()
+    auth_header = auth.login()
     with client:
         client.get("/")
 
@@ -13,7 +13,7 @@ def test_create_semmap(client, auth):
                                       'name': 'CDU',
                                       'description': 'Test Query'
                                   },
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
 
         # constellation
         constellation = client.post(url_for('constellation.create'),
@@ -22,7 +22,7 @@ def test_create_semmap(client, auth):
                                         'description': 'Test Constellation 1',
                                         'filter_discourseme_ids': [discourseme.json['id']]
                                     },
-                                    auth=('admin', '0000'))
+                                    headers=auth_header)
 
         # query
         query = client.post(url_for('query.create'),
@@ -31,11 +31,11 @@ def test_create_semmap(client, auth):
                                 'corpus_id': 1,
                                 'cqp_query': '[lemma="Bundeskanzler"]'
                             },
-                            auth=('admin', '0000'))
+                            headers=auth_header)
 
         # execute
         query = client.post(url_for('query.execute', id=query.json['id']),
-                            auth=('admin', '0000'))
+                            headers=auth_header)
 
         # collocation
         collocation = client.post(url_for('collocation.create', query_id=query.json['id']),
@@ -45,19 +45,19 @@ def test_create_semmap(client, auth):
                                       's_break': 's',
                                       'context': 5,
                                   },
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
 
         collocation = client.get(url_for('collocation.get_collocation', query_id=query.json['id'], id=collocation.json['id']),
-                                 auth=('admin', '0000'))
+                                 headers=auth_header)
 
         collocation = client.post(url_for('collocation.execute', query_id=query.json['id'], id=collocation.json['id']),
-                                  auth=('admin', '0000'))
+                                  headers=auth_header)
 
         assert collocation.status_code == 200
 
         # semmap
         semantic_map = client.post(url_for('collocation.create_semantic_map', query_id=query.json['id'], id=collocation.json['id']),
-                                   auth=('admin', '0000'))
+                                   headers=auth_header)
 
         assert semantic_map.status_code == 200
 
@@ -68,9 +68,9 @@ def test_create_semmap(client, auth):
 #     with client:
 #         client.get("/")
 #         client.post(url_for('semantic_map.execute', id=1),
-#                     auth=('admin', '0000'))
+#                     headers=auth_header)
 
 #         items = client.get(url_for('semantic_map.get_coordinates', id=1),
-#                            auth=('admin', '0000'))
+#                            headers=auth_header)
 
 #         assert items.status_code == 200


### PR DESCRIPTION
subcorpora
- subcorpora are now defined via segmentation spans (instead of matches)
- renamed subcorpus naming conventions, most notably `nqr_cqp` instead of `cqp_nqr_matches`
- *always* refer to subcorpora via their `id` (instead of implicitly searching save NQRs in CQP)
- CLI commands: 
  - `corpus import`
  - `corpus subcorpora`
  - `corpus read-meta`

concordance
- new input and output schemata, most notably token-based arrays
- pagination for `/query/{query_id}/concordance/`
  - `page_size` and `page_nr`
  - also accepts sorting parameters `sort_order`, `sort_by` (WIP)
  - also accepts filtering parameters `filter_item` and `filter_discourseme_ids` (WIP)
- context retrieval for single concordance line via `/query/{query_id}/concordance/{id}`

access and refresh tokens
- access token expires in 30 min
- `POST /user/refresh` accepts refresh token in body, returns new refresh and access tokens

also: repaired tests