### PR TITLE
Require context break to be set manually for constellation collocation analysis

### DIFF
--- a/frontend/mmda/src/routes/_app/constellations_/$constellationId/-constellation-filter.tsx
+++ b/frontend/mmda/src/routes/_app/constellations_/$constellationId/-constellation-filter.tsx
@@ -200,6 +200,7 @@ export function ConstellationConcordanceFilter({
       )}
     >
       {!hideWindowSize && <WindowSizeInput />}
+
       {!hideFocusDiscourseme && (
         <LabelBox labelText="Focus Discourseme">
           <FocusDiscourseme />

--- a/frontend/mmda/src/routes/_app/constellations_/$constellationId/-use-description.ts
+++ b/frontend/mmda/src/routes/_app/constellations_/$constellationId/-use-description.ts
@@ -3,7 +3,11 @@ import { useQuery } from '@tanstack/react-query'
 import { constellationDescriptionFor, corpusById } from '@cads/shared/queries'
 import { Route } from './route'
 
-export function useDescription() {
+export function useDescription({
+  mayDefaultToFirstAnnotation = true,
+}: {
+  mayDefaultToFirstAnnotation?: boolean
+} = {}) {
   const constellationId = parseInt(Route.useParams().constellationId)
   const searchParams = Route.useSearch()
   const corpusId = searchParams.corpusId
@@ -20,7 +24,7 @@ export function useDescription() {
   const contextBreak =
     searchParams.contextBreak ||
     searchParams.clContextBreak ||
-    data?.s_annotations?.[0]
+    (mayDefaultToFirstAnnotation ? data?.s_annotations?.[0] : undefined)
 
   const {
     data: description,

--- a/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/-concordance-lines.tsx
+++ b/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/-concordance-lines.tsx
@@ -13,9 +13,9 @@ import {
 } from '@cads/shared/components/concordances'
 import { ConstellationConcordanceFilter } from '@/routes/_app/constellations_/$constellationId/-constellation-filter'
 
-import { useDescription } from '../-use-description'
 import { useCollocationSelection } from './-use-collocation-selection'
 import { Route } from './route'
+import { useCollocationAnalysisDescription } from './-use-collocation-analysis-description'
 
 export function ConstellationConcordanceLines() {
   const constellationId = parseInt(Route.useParams().constellationId)
@@ -41,7 +41,7 @@ export function ConstellationConcordanceLines() {
     setFilterItem,
   } = useConcordanceFilterContext()
 
-  const descriptionId = useDescription()?.description?.id
+  const descriptionId = useCollocationAnalysisDescription()?.description?.id
 
   const enabled =
     focusDiscourseme !== undefined &&

--- a/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/-map-preview.tsx
+++ b/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/-map-preview.tsx
@@ -1,7 +1,7 @@
 import { ErrorMessage } from '@cads/shared/components/error-message'
 import { WordCloudLink } from '@/components/word-cloud-link'
 
-import { useDescription } from '../-use-description'
+import { useCollocationAnalysisDescription } from './-use-collocation-analysis-description'
 import { useCollocationSelection } from './-use-collocation-selection'
 import { useCollocation } from '../-use-collocation'
 import { Route } from './route'
@@ -10,7 +10,7 @@ export function CollocationMapPreview() {
   const constellationId = parseInt(Route.useParams().constellationId)
   const { corpusId, contextBreak, analysisLayer, focusDiscourseme } =
     useCollocationSelection()
-  const descriptionId = useDescription()?.description?.id
+  const descriptionId = useCollocationAnalysisDescription()?.description?.id
   const { mapItems, error } = useCollocation(descriptionId)
 
   if (error) {

--- a/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/-selection.tsx
+++ b/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/-selection.tsx
@@ -18,7 +18,7 @@ import { SelectSingle } from '@cads/shared/components/select-single'
 import { cn } from '@cads/shared/lib/utils'
 
 import { useCollocationSelection } from './-use-collocation-selection'
-import { useDescription } from '../-use-description'
+import { useCollocationAnalysisDescription } from './-use-collocation-analysis-description'
 
 export function CollocationSelection() {
   const { corpusId } = useCollocationSelection()
@@ -75,11 +75,11 @@ function AnalysisLayerInput() {
 }
 
 function FocusDiscoursemeInput({ className }: { className?: string }) {
-  const { corpusId, focusDiscourseme, setFocusDiscourseme } =
+  const { contextBreak, corpusId, focusDiscourseme, setFocusDiscourseme } =
     useCollocationSelection()
 
   const { description, isLoadingDescription, errorDescription } =
-    useDescription()
+    useCollocationAnalysisDescription()
   const { data: discoursemes = [] } = useQuery(discoursemesList)
 
   const constellationIds = (description?.discourseme_descriptions ?? []).map(
@@ -96,17 +96,23 @@ function FocusDiscoursemeInput({ className }: { className?: string }) {
     >
       <ErrorMessage error={errorDescription} className="col-span-full" />
 
-      <DiscoursemeSelect
-        discoursemes={discoursemesInDescription}
-        discoursemeId={focusDiscourseme}
-        onChange={setFocusDiscourseme}
-        disabled={isLoadingDescription || corpusId === undefined}
-        className="w-full"
-      />
+      <div className="relative">
+        <DiscoursemeSelect
+          discoursemes={discoursemesInDescription}
+          discoursemeId={focusDiscourseme}
+          onChange={setFocusDiscourseme}
+          disabled={
+            isLoadingDescription ||
+            corpusId === undefined ||
+            contextBreak === undefined
+          }
+          className="w-full"
+        />
 
-      {isLoadingDescription && (
-        <Loader2Icon className="absolute left-1/2 top-2 animate-spin" />
-      )}
+        {isLoadingDescription && (
+          <Loader2Icon className="absolute left-1/2 top-2 animate-spin" />
+        )}
+      </div>
     </LabelBox>
   )
 }

--- a/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/-semantic-map.tsx
+++ b/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/-semantic-map.tsx
@@ -25,7 +25,7 @@ import { useConcordanceFilterContext } from '@cads/shared/components/concordance
 import { CutOffSelect } from '@/components/word-cloud/cut-off-select'
 import { LabelBox } from '@cads/shared/components/label-box'
 
-import { useDescription } from '../-use-description'
+import { useCollocationAnalysisDescription } from './-use-collocation-analysis-description'
 import { useCollocation } from '../-use-collocation'
 import { ConstellationCollocationFilter } from '../-constellation-filter'
 import { ConstellationDiscoursemesEditor } from '../-constellation-discoursemes-editor'
@@ -43,7 +43,7 @@ export function CollocationSemanticMap() {
   const { isFaultySelection, analysisLayer } = useCollocationSelection()
   const [cutOff, setCutOff] = useState(0.5)
 
-  const { description } = useDescription()
+  const { description } = useCollocationAnalysisDescription()
   const {
     mapItems,
     isFetching,

--- a/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/-use-collocation-analysis-description.ts
+++ b/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/-use-collocation-analysis-description.ts
@@ -1,0 +1,5 @@
+import { useDescription } from '../-use-description'
+
+export function useCollocationAnalysisDescription() {
+  return useDescription({ mayDefaultToFirstAnnotation: false })
+}

--- a/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/-use-collocation-selection.ts
+++ b/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/-use-collocation-selection.ts
@@ -34,7 +34,10 @@ export function useCollocationSelection() {
   })
 
   analysisLayer = defaultValue(layers, analysisLayer, 'lemma')
-  contextBreak = defaultValue(structuredAttributes, contextBreak)
+  contextBreak = defaultValue(
+    [...(structuredAttributes ?? []), undefined],
+    contextBreak,
+  )
 
   const isValidSelection =
     corpusId !== undefined &&
@@ -85,7 +88,7 @@ export function useCollocationSelection() {
       navigate({
         to: '.',
         params: (p) => p,
-        search: (s) => ({ ...s, contextBreak }),
+        search: (s) => ({ ...s, contextBreak, focusDiscourseme: undefined }),
       }),
   }
 }

--- a/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/route.lazy.tsx
+++ b/frontend/mmda/src/routes/_app/constellations_/$constellationId/collocation-analysis/route.lazy.tsx
@@ -8,7 +8,7 @@ import { CollocationTable } from './-collocation-table'
 import { ConstellationConcordanceLines } from './-concordance-lines'
 import { ConstellationCollocationFilter } from '../-constellation-filter'
 import { useCollocationSelection } from './-use-collocation-selection'
-import { useDescription } from '../-use-description'
+import { useCollocationAnalysisDescription } from './-use-collocation-analysis-description'
 
 export const Route = createLazyFileRoute(
   '/_app/constellations_/$constellationId/collocation-analysis',
@@ -17,7 +17,7 @@ export const Route = createLazyFileRoute(
 })
 
 function CollocationAnalysis() {
-  const descriptionId = useDescription().description?.id
+  const descriptionId = useCollocationAnalysisDescription().description?.id
   const { isValidSelection } = useCollocationSelection()
 
   return (


### PR DESCRIPTION
Fixes https://github.com/ausgerechnet/cwb-cads/issues/8

The constellation collocation analysis view now requires the user to explicitly set the context break.